### PR TITLE
Upadate role "lxd-inst"

### DIFF
--- a/T-LAB/roles/lxd-inst/defaults/main.yml
+++ b/T-LAB/roles/lxd-inst/defaults/main.yml
@@ -8,7 +8,6 @@ lxd_packages:
   - "unzip"
   - "epel-release"
   - "libselinux-python"
-  - "yum-plugin-copr"
 
 zfs_packages:
   - "kernel-devel"

--- a/T-LAB/roles/lxd-inst/tasks/main.yml
+++ b/T-LAB/roles/lxd-inst/tasks/main.yml
@@ -68,12 +68,6 @@
     state: present
   when: zfs_deploy
 
-- name: enable snapcore-el7 repo
-  command: "yum copr enable -y ngompa/snapcore-el7"
-  args:
-    creates: /etc/yum.repos.d/_copr_ngompa-snapcore-el7.repo
-    warn: False
-
 - name: install snapd
   yum:
     name: snapd

--- a/T-LAB/roles/lxd-inst/tasks/main.yml
+++ b/T-LAB/roles/lxd-inst/tasks/main.yml
@@ -91,9 +91,8 @@
     seconds: 3
 
 - name: install LXD with snap
-  command: snap install lxd
-  args:
-    creates: /var/snap/lxd/
+  snap:
+    name: lxd
   tags: snaplxd
 
 - name: adding existing user to group lxd


### PR DESCRIPTION
Удалил таск "enable snapcore-el7 repo" - не актуален, пакет snapd уже есть в репозитории epel
В переменных lxd_packages удалил пакет yum-plugin-copr - не актуален, потому что используется только в таске "enable snapcore-el7 repo"
Поменял таск "install LXD with snap" - в ansible 2.8 появился родной модуль для snap